### PR TITLE
feat: binary operator

### DIFF
--- a/Papyrus/Builders.lean
+++ b/Papyrus/Builders.lean
@@ -174,6 +174,11 @@ def callAs (type : FunctionTypeRef) (fn : ValueRef) (args : Array ValueRef := #[
 
 -- ## Binary Operators
 
+def binop (op : InstructionKind) (s1 s2 : ValueRef) (name : String := "") (h : op.is_binary_op := by trivial) : BasicBlockM BinaryOperatorRef := do
+  let inst ← BinaryOperatorRef.create op s1 s2 name h
+  (← read).bbRef.appendInstruction inst
+  return inst
+
 def add (s1 s2 : ValueRef) (name : String := "") : BasicBlockM BinaryOperatorRef := do
   let inst ← BinaryOperatorRef.create InstructionKind.add s1 s2 name
   (← read).bbRef.appendInstruction inst
@@ -260,6 +265,6 @@ def or (s1 s2 : ValueRef) (name : String := "") : BasicBlockM BinaryOperatorRef 
   return inst
 
 def xor (s1 s2 : ValueRef) (name : String := "") : BasicBlockM BinaryOperatorRef := do
-  let inst ← BinaryOperatorRef.create InstructionKind.xor   s1 s2 name
+  let inst ← BinaryOperatorRef.create InstructionKind.xor s1 s2 name
   (← read).bbRef.appendInstruction inst
   return inst

--- a/Papyrus/Builders.lean
+++ b/Papyrus/Builders.lean
@@ -171,3 +171,95 @@ def callAs (type : FunctionTypeRef) (fn : ValueRef) (args : Array ValueRef := #[
   let inst ← CallInstRef.create type fn args name
   (← read).bbRef.appendInstruction inst
   return inst
+
+-- ## Binary Operators
+
+def add (s1 s2 : ValueRef) (name : String := "") : BasicBlockM BinaryOperatorRef := do
+  let inst ← BinaryOperatorRef.create InstructionKind.add s1 s2 name
+  (← read).bbRef.appendInstruction inst
+  return inst
+
+def fadd (s1 s2 : ValueRef) (name : String := "") : BasicBlockM BinaryOperatorRef := do
+  let inst ← BinaryOperatorRef.create InstructionKind.fadd s1 s2 name
+  (← read).bbRef.appendInstruction inst
+  return inst
+
+def sub (s1 s2 : ValueRef) (name : String := "") : BasicBlockM BinaryOperatorRef := do
+  let inst ← BinaryOperatorRef.create InstructionKind.sub s1 s2 name
+  (← read).bbRef.appendInstruction inst
+  return inst
+
+def fsub (s1 s2 : ValueRef) (name : String := "") : BasicBlockM BinaryOperatorRef := do
+  let inst ← BinaryOperatorRef.create InstructionKind.fsub s1 s2 name
+  (← read).bbRef.appendInstruction inst
+  return inst
+
+def mul (s1 s2 : ValueRef) (name : String := "") : BasicBlockM BinaryOperatorRef := do
+  let inst ← BinaryOperatorRef.create InstructionKind.mul s1 s2 name
+  (← read).bbRef.appendInstruction inst
+  return inst
+
+def fmul (s1 s2 : ValueRef) (name : String := "") : BasicBlockM BinaryOperatorRef := do
+  let inst ← BinaryOperatorRef.create InstructionKind.fmul s1 s2 name
+  (← read).bbRef.appendInstruction inst
+  return inst
+
+def udiv (s1 s2 : ValueRef) (name : String := "") : BasicBlockM BinaryOperatorRef := do
+  let inst ← BinaryOperatorRef.create InstructionKind.udiv s1 s2 name
+  (← read).bbRef.appendInstruction inst
+  return inst
+
+def sdiv (s1 s2 : ValueRef) (name : String := "") : BasicBlockM BinaryOperatorRef := do
+  let inst ← BinaryOperatorRef.create InstructionKind.sdiv s1 s2 name
+  (← read).bbRef.appendInstruction inst
+  return inst
+
+def fdiv (s1 s2 : ValueRef) (name : String := "") : BasicBlockM BinaryOperatorRef := do
+  let inst ← BinaryOperatorRef.create InstructionKind.fdiv s1 s2 name
+  (← read).bbRef.appendInstruction inst
+  return inst
+
+def urem (s1 s2 : ValueRef) (name : String := "") : BasicBlockM BinaryOperatorRef := do
+  let inst ← BinaryOperatorRef.create InstructionKind.urem s1 s2 name
+  (← read).bbRef.appendInstruction inst
+  return inst
+
+def srem (s1 s2 : ValueRef) (name : String := "") : BasicBlockM BinaryOperatorRef := do
+  let inst ← BinaryOperatorRef.create InstructionKind.srem s1 s2 name
+  (← read).bbRef.appendInstruction inst
+  return inst
+
+def frem (s1 s2 : ValueRef) (name : String := "") : BasicBlockM BinaryOperatorRef := do
+  let inst ← BinaryOperatorRef.create InstructionKind.frem s1 s2 name
+  (← read).bbRef.appendInstruction inst
+  return inst
+
+def shl (s1 s2 : ValueRef) (name : String := "") : BasicBlockM BinaryOperatorRef := do
+  let inst ← BinaryOperatorRef.create InstructionKind.shl s1 s2 name
+  (← read).bbRef.appendInstruction inst
+  return inst
+
+def lshr (s1 s2 : ValueRef) (name : String := "") : BasicBlockM BinaryOperatorRef := do
+  let inst ← BinaryOperatorRef.create InstructionKind.lshr s1 s2 name
+  (← read).bbRef.appendInstruction inst
+  return inst
+
+def ashr (s1 s2 : ValueRef) (name : String := "") : BasicBlockM BinaryOperatorRef := do
+  let inst ← BinaryOperatorRef.create InstructionKind.ashr s1 s2 name
+  (← read).bbRef.appendInstruction inst
+  return inst
+
+def and (s1 s2 : ValueRef) (name : String := "") : BasicBlockM BinaryOperatorRef := do
+  let inst ← BinaryOperatorRef.create InstructionKind.and s1 s2 name
+  (← read).bbRef.appendInstruction inst
+  return inst
+
+def or (s1 s2 : ValueRef) (name : String := "") : BasicBlockM BinaryOperatorRef := do
+  let inst ← BinaryOperatorRef.create InstructionKind.or s1 s2 name
+  (← read).bbRef.appendInstruction inst
+  return inst
+
+def xor (s1 s2 : ValueRef) (name : String := "") : BasicBlockM BinaryOperatorRef := do
+  let inst ← BinaryOperatorRef.create InstructionKind.xor   s1 s2 name
+  (← read).bbRef.appendInstruction inst
+  return inst

--- a/Papyrus/IR/InstructionKind.lean
+++ b/Papyrus/IR/InstructionKind.lean
@@ -94,3 +94,6 @@ def ofOpcode! (opcode : UInt32) : InstructionKind :=
 
 def toOpcode (self : InstructionKind) : UInt32 :=
   self.val.toUInt32 + 1
+
+def is_binary_op (self : InstructionKind) : Prop :=
+  (self.val < InstructionKind.alloca.val) && (InstructionKind.fneg.val < self.val) 

--- a/Papyrus/IR/InstructionRefs.lean
+++ b/Papyrus/IR/InstructionRefs.lean
@@ -414,7 +414,6 @@ end FunctionRef
 -/
 structure  BinaryOperatorRef extends InstructionRef
 instance : Coe BinaryOperatorRef InstructionRef := ⟨(·.toInstructionRef)⟩
-instance : Coe BinaryOperatorRef ValueRef := ⟨(·.toValueRef)⟩
 
 namespace BinaryOperatorRef
 /-- Create a new binary instruction, given the opcode and the two operands.  -/

--- a/Papyrus/IR/InstructionRefs.lean
+++ b/Papyrus/IR/InstructionRefs.lean
@@ -403,3 +403,21 @@ def createCall
   CallInstRef.create (← self.getFunctionType) self args name
 
 end FunctionRef
+
+--------------------------------------------------------------------------------
+-- # Binary Operators
+--------------------------------------------------------------------------------
+
+/--
+  A reference to an external LLVM
+  [Binary Operator](https://llvm.org/doxygen/classllvm_1_1BinaryOperator.html).
+-/
+structure  BinaryOperatorRef extends InstructionRef
+instance : Coe BinaryOperatorRef InstructionRef := ⟨(·.toInstructionRef)⟩
+instance : Coe BinaryOperatorRef ValueRef := ⟨(·.toValueRef)⟩
+
+namespace BinaryOperatorRef
+/-- Create a new binary instruction, given the opcode and the two operands.  -/
+@[extern "papyrus_binary_operator_create"]
+constant create (op : InstructionKind) (s1 : @& ValueRef) (s2 : @& ValueRef) (name : @& String := "") (h : op.is_binary_op := by trivial) : IO BinaryOperatorRef
+end BinaryOperatorRef

--- a/c/src/instruction.cpp
+++ b/c/src/instruction.cpp
@@ -437,8 +437,8 @@ extern "C" lean_obj_res papyrus_call_inst_create
 // Binary Operator
 //------------------------------------------------------------------------------
 extern "C" lean_obj_res papyrus_binary_operator_create
-	(uint8_t opcodeKind, b_lean_obj_res s1, b_lean_obj_res s2,  b_lean_obj_res nameObj, lean_obj_arg /* w */) {
-	auto inst = BinaryOperator::Create(static_cast<Instruction::BinaryOps>(opcodeKind+1), toValue(s1), toValue(s1), refOfString(nameObj));
+	(uint32_t opCode, b_lean_obj_res s1, b_lean_obj_res s2,  b_lean_obj_res nameObj, lean_obj_arg /* w */) {
+	auto inst = BinaryOperator::Create(static_cast<Instruction::BinaryOps>(opCode + 1), toValue(s1), toValue(s2), refOfString(nameObj));
 	return lean_io_result_mk_ok(mkValueRef(copyLink(s1), inst));
 }
 

--- a/c/src/instruction.cpp
+++ b/c/src/instruction.cpp
@@ -433,4 +433,15 @@ extern "C" lean_obj_res papyrus_call_inst_create
 	return lean_io_result_mk_ok(mkValueRef(copyLink(typeRef), i));
 }
 
+//------------------------------------------------------------------------------
+// Binary Operator
+//------------------------------------------------------------------------------
+extern "C" lean_obj_res papyrus_binary_operator_create
+	(uint8_t opcodeKind, b_lean_obj_res s1, b_lean_obj_res s2,  b_lean_obj_res nameObj, lean_obj_arg /* w */) {
+	auto inst = BinaryOperator::Create(static_cast<Instruction::BinaryOps>(opcodeKind+1), toValue(s1), toValue(s1), refOfString(nameObj));
+	return lean_io_result_mk_ok(mkValueRef(copyLink(s1), inst));
+}
+
+
+
 } // end namespace papyrus

--- a/test/out/script/dump.lean
+++ b/test/out/script/dump.lean
@@ -32,3 +32,38 @@ llvm module hello do
 #dump llvm i64 -1
 #dump llvm i128 1208925819614629174706188 -- 2^80 + 12
 #dump llvm i128 -1208925819614629174706188
+
+
+-- # Ops
+
+llvm module ops do
+  define i32 @opsEx(i32 %a, i32 %b) do
+    %c = add i32 %a, %b
+    %d = mul i32 %a, %b
+    %e = sub i32 %a, %b
+    %f = udiv i32 %a, %b 
+    %g = sdiv i32 %a, %b 
+    %h = urem i32 %a, %b
+    %i = srem i32 %a, %b
+    %j = shl i32 %a, %b
+    %k = lshr i32 %a, %b
+    %l = ashr i32 %a, %b
+    %m = and i32 %a, %b
+    %n = or i32 %a, %b
+    %o = xor i32 %a, %b
+    ret i32 0
+
+  define i32 @mulEx(i32 %a, i32 %b) do
+    %d = mul i32 %a, %b
+    ret i32 0
+
+  define float @fopsEx(float %a, float %b) do
+    %c = fadd float %a, %b
+    %d = fsub float %a, %b
+    %e = fmul float %a, %b
+    %f = fdiv float %a, %b
+    %g = frem float %a, %b
+    ret i32 0
+
+
+#dump ops

--- a/test/out/script/dump.lean.expected.out
+++ b/test/out/script/dump.lean.expected.out
@@ -24,3 +24,36 @@ i32 1
 i64 -1
 i128 1208925819614629174706188
 i128 -1208925819614629174706188
+; ModuleID = 'ops'
+source_filename = "ops"
+
+define i32 @opsEx(i32 %a, i32 %b) {
+  %c = add i32 %a, %b
+  %d = mul i32 %a, %b
+  %e = sub i32 %a, %b
+  %f = udiv i32 %a, %b
+  %g = sdiv i32 %a, %b
+  %h = urem i32 %a, %b
+  %i = srem i32 %a, %b
+  %j = shl i32 %a, %b
+  %k = lshr i32 %a, %b
+  %l = ashr i32 %a, %b
+  %m = and i32 %a, %b
+  %n = or i32 %a, %b
+  %o = xor i32 %a, %b
+  ret i32 0
+}
+
+define i32 @mulEx(i32 %a, i32 %b) {
+  %d = mul i32 %a, %b
+  ret i32 0
+}
+
+define float @fopsEx(float %a, float %b) {
+  %c = fadd float %a, %b
+  %d = fsub float %a, %b
+  %e = fmul float %a, %b
+  %f = fdiv float %a, %b
+  %g = frem float %a, %b
+  ret i32 0
+}

--- a/test/run/ir/instructionRefs.lean
+++ b/test/run/ir/instructionRefs.lean
@@ -129,3 +129,9 @@ def assertBEq [Repr α] [BEq α] (expected actual : α) : IO PUnit := do
   let inst ← CallInstRef.create fnTy fn #[]
   assertBEq ValueKind.instruction inst.valueKind
   assertBEq InstructionKind.call inst.instructionKind
+
+-- binary operations
+#eval LlvmM.run do
+  let n ← ConstantIntRef.ofUInt64 20
+  let m ← ConstantIntRef.ofUInt64 10
+  let op ← BinaryOperatorRef.create InstructionKind.add n m


### PR DESCRIPTION
Implements creation of binary operator instructions. It might make sense to use the [IRBuilderBase](https://llvm.org/doxygen/classllvm_1_1IRBuilderBase.html) creation methods instead of these, since it contains a ton of convenience functions for creation of intrinsics and has a very homogeneous API, which would be easy albeit slightly tedious to wrap.